### PR TITLE
Sync 1.0.1 progressive history into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.1
+
+_Based on Catalyst (`@bigcommerce/catalyst-makeswift`) 1.7.0_
+
+### Summary
+
+Affects only commit history. Standardized the way TODOs are introduced in step history and consolidated metadata to end of history.
+
 ## 1.0.0
 
 _Based on Catalyst (`@bigcommerce/catalyst-makeswift`) 1.7.0_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
-AGENTS.md
+# CLAUDE.md
+
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Body:
 {
     "key": "ship-time",
     "value": "{ \"question\": \"How quickly does this product ship?\", \"answer\": \"The product ships within 2 days.\" }",
-    "namespace": "FAQ",
+    "namespace": "FAQ|en",
     "permission_set": "read_and_sf_access"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "nextjs"
   ],
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184",
   "scripts": {


### PR DESCRIPTION
## Summary

Replicates the final state of the `1.0.1` progressive history onto `main` (produced via `bcedu-lab-sync` `sync-to-main`). `validate-sync` confirms the branch tree is identical to the `1.0.1` tip.

The `1.0.1` history affects only commit structure (standardized 1:1 TODO→code commits and consolidated metadata at the end of history); the synced content delta from `1.0.0` is:

- `package.json` — version `1.0.0` → `1.0.1`
- `CHANGELOG.md` — add the `1.0.1` entry
- `README.md` — metafield `namespace` example `"FAQ"` → `"FAQ|en"`
- `CLAUDE.md` — symlink → regular file using the `@AGENTS.md` import directive

## Test plan

- [ ] Confirm `git diff 1.0.1 <merge-result>` is empty after merge (trees identical)
- [ ] Verify `package.json` version is `1.0.1`